### PR TITLE
Removed the node.js platform from the Vagrantfile.  We install the relev...

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	end
 
 	config.vm.provision :ventriloquist do |env|
-		env.platforms << %w( nodejs-0.10 )
 		env.packages << %w( tmux build-essential checkinstall exuberant-ctags curl python-pip vim-nox git-flow cmake dstat gnuplot gdb unzip )
 	end
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -85,7 +85,7 @@ case $(id -u) in
 
 		if ! hash http 2>/dev/null; then
 			echo "Installing HTTP (human readable version of CURL)"
-			pip install --upgrade httpie
+			sudo pip install --upgrade httpie
 			echo "Done - see https://github.com/jakubroztocil/httpie"
 		fi
 		;;


### PR DESCRIPTION
...ant node.js inside of the bootstrap.sh.  I would say this is a temporary fix as it would be good to keep true to ventriloquist if we are using it.  Also inside of bootstrap, pip was failing due to permissions so prefixed it with sudo.
